### PR TITLE
 FlaskPlugin: Don't add APPLICATION_ROOT to paths. 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.3.0 (unreleased)
+++++++++++++++++++
+
+* FlaskPlugin: Don't add APPLICATION_ROOT to paths (:issue:`19`).
+
 0.2.0 (2018-11-06)
 ++++++++++++++++++
 

--- a/apispec_webframeworks/flask.py
+++ b/apispec_webframeworks/flask.py
@@ -66,11 +66,6 @@ Passing a method view function::
 from __future__ import absolute_import
 import re
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
-
 from flask import current_app
 from flask.views import MethodView
 
@@ -118,6 +113,4 @@ class FlaskPlugin(BasePlugin):
                     method_name = method.lower()
                     method = getattr(view.view_class, method_name)
                     operations[method_name] = yaml_utils.load_yaml_from_docstring(method.__doc__)
-        path = self.flaskpath2openapi(rule.rule)
-        app_root = current_app.config['APPLICATION_ROOT'] or '/'
-        return urljoin(app_root.rstrip('/') + '/', path.lstrip('/'))
+        return self.flaskpath2openapi(rule.rule)

--- a/apispec_webframeworks/tests/test_ext_flask.py
+++ b/apispec_webframeworks/tests/test_ext_flask.py
@@ -174,39 +174,3 @@ class TestPathHelpers:
 
         spec.path(view=get_pet)
         assert '/pet/{pet_id}' in get_paths(spec)
-
-    def test_path_includes_app_root(self, app, spec):
-
-        spec.options['basePath'] = '/v1'
-        app.config['APPLICATION_ROOT'] = '/v1/app/root'
-
-        @app.route('/partial/path/pet')
-        def get_pet():
-            return 'pet'
-
-        spec.path(view=get_pet)
-        assert '/app/root/partial/path/pet' in get_paths(spec)
-
-    def test_path_with_args_includes_app_root(self, app, spec):
-
-        spec.options['basePath'] = '/v1'
-        app.config['APPLICATION_ROOT'] = '/v1/app/root'
-
-        @app.route('/partial/path/pet/{pet_id}')
-        def get_pet(pet_id):
-            return 'representation of pet {pet_id}'.format(pet_id=pet_id)
-
-        spec.path(view=get_pet)
-        assert '/app/root/partial/path/pet/{pet_id}' in get_paths(spec)
-
-    def test_path_includes_app_root_with_right_slash(self, app, spec):
-
-        spec.options['basePath'] = '/v1'
-        app.config['APPLICATION_ROOT'] = '/v1/app/root/'
-
-        @app.route('/partial/path/pet')
-        def get_pet():
-            return 'pet'
-
-        spec.path(view=get_pet)
-        assert '/app/root/partial/path/pet' in get_paths(spec)


### PR DESCRIPTION
Closes #19.