### PR TITLE
Flask DocumentBlueprint: Add to spec all views defined in the blueprint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,5 +100,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# Editors
+.idea/
+.vscode/
+
 # mypy
 .mypy_cache/

--- a/apispec_webframeworks/tests/test_ext_flask.py
+++ b/apispec_webframeworks/tests/test_ext_flask.py
@@ -180,7 +180,7 @@ class TestDocumentedBlueprint:
     def test_document_document_true(self, app, spec):
         documented_blueprint = DocumentedBlueprint('test', __name__, spec)
 
-        @documented_blueprint.route('/test', document=True)
+        @documented_blueprint.route('/test', documented=True)
         def test():
             return 'Hello'
 
@@ -191,7 +191,7 @@ class TestDocumentedBlueprint:
     def test_document_document_false(self, app, spec):
         documented_blueprint = DocumentedBlueprint('test', __name__, spec)
 
-        @documented_blueprint.route('/test', document=False)
+        @documented_blueprint.route('/test', documented=False)
         def test():
             return 'Hello'
 


### PR DESCRIPTION
# Flask DocumentBlueprint
Is a blueprint  which adds all views defined in it to the spec. You can ommit one view from being added to the spec setting `documented=False` in the Blueprint's `route` function (see usage below).

## Usage
```python

from flask import Flask
from flask.views import MethodView

app = Flask(__name__)

documented_blueprint = DocumentedBlueprint('gistapi', __name__)

@documented_blueprint.route('/gists/<gist_id>')
def gist_detail(gist_id):
    '''Gist detail view.
    ---
    x-extension: metadata
    get:
        responses:
            200:
                schema:
                    $ref: '#/definitions/Gist'
    '''
    return 'detail for gist {}'.format(gist_id)


@documented_blueprint.route('/repos/<repo_id>', documented=False)
def repo_detail(repo_id):
    '''This endpoint won't be documented
    ---
    x-extension: metadata
    get:
        responses:
            200:
                schema:
                    $ref: '#/definitions/Repo'
    '''
    return 'detail for repo {}'.format(repo_id)

app.register_blueprint(documented_blueprint)

print(spec.to_dict()['paths'])
# {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}},
#                  'x-extension': 'metadata'}}

```

Has a test coverage of 100%.