### PR TITLE
Allow passing flask app as kwarg of `spec.path`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors (chronological)
 - Felix Yan `@felixonmars <https://github.com/felixonmars>`_
 - Jérôme Lafréchoux `@lafrech <https://github.com/lafrech>`_
 - Marcin Lulek `@ergo <https://github.com/ergo>`_
+- Aaron Ramshaw `@ramshaw888 <https://github.com/ramshaw888>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+0.4.0 (unreleased)
+++++++++++++++++++
+
+* FlaskPlugin: Allow passing an app to ``spec.path`` (:pr:`33`).
+  Thanks :user:`ramshaw888`.
+
 0.3.0 (2019-01-31)
 ++++++++++++++++++
 

--- a/apispec_webframeworks/tests/test_ext_flask.py
+++ b/apispec_webframeworks/tests/test_ext_flask.py
@@ -174,3 +174,13 @@ class TestPathHelpers:
 
         spec.path(view=get_pet)
         assert '/pet/{pet_id}' in get_paths(spec)
+
+    def test_explicit_app_kwarg(self, spec):
+        app = Flask(__name__)
+
+        @app.route('/pet/<pet_id>')
+        def get_pet(pet_id):
+            return 'representation of pet {pet_id}'.format(pet_id=pet_id)
+
+        spec.path(view=get_pet, app=app)
+        assert '/pet/{pet_id}' in get_paths(spec)


### PR DESCRIPTION
Most of the time we're going to be adding paths to the `spec` object at the same time when we're initialising the flask app and doing various config etc. (e.g. http://flask.pocoo.org/docs/1.0/patterns/appfactories/). It makes sense to me that we would allow the explicit passing of the app object when registering paths with `spec`.