### PR TITLE
Unpin tornado

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 VERSION = "0.4.0"
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "mock", "Flask==1.1.0", "tornado==5.1.1", "bottle==0.12.17"],
+    "tests": ["pytest", "mock", "Flask==1.1.0", "tornado", "bottle==0.12.17"],
     "lint": [
         "flake8==3.7.7",
         'flake8-bugbear==19.3.0; python_version >= "3.5"',


### PR DESCRIPTION
Allow setuptools to determine a compatible version using python_requires.

close #48 