### PR TITLE
test against python3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ resources:
 jobs:
 - template: job--python-tox.yml@sloria
   parameters:
-    toxenvs: [lint, py36, py37, py37-apispecdev]
+    toxenvs: [lint, py36, py37, py38, py38-apispecdev]
     os: linux
 - template: job--pypi-release.yml@sloria
   parameters:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     lint
-    py{36,37}
+    py{36,37,38}
     py37-apispecdev
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     lint
     py{36,37,38}
-    py37-apispecdev
+    py38-apispecdev
 
 [testenv]
 extras = tests


### PR DESCRIPTION
Let's test against latest python as well. Nothing broke

I would merge this myself but have a question: what about the `py37-apispecdev` env? Do we change that to `py38` as well? upstream apispec still uses 37 to test against marshmallow-dev