### PR TITLE
Adding support for AWS Chalice framework

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Contributors (chronological)
 - Marcin Lulek `@ergo <https://github.com/ergo>`_
 - Aaron Ramshaw `@ramshaw888 <https://github.com/ramshaw888>`_
 - PelleK `@elfjes <https://github.com/elfjes>`_
+- Tim Reidel `@reidelt <https://github.com/reidelt>'

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Included plugins:
 * ``apispec_webframeworks.bottle``
 * ``apispec_webframeworks.flask``
 * ``apispec_webframeworks.tornado``
+* ``apispec_webframeworks.chalice``
 
 Migration from ``apispec<1.0.0``
 ================================

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 VERSION = "0.5.2"
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "mock", "Flask==1.1.2", "tornado", "bottle==0.12.18"],
+    "tests": ["pytest", "mock", "Flask==1.1.2", "tornado", "bottle==0.12.18", "chalice"],
     "lint": ["flake8==3.8.0", "flake8-bugbear==20.1.4", "pre-commit>=1.18,<3.0"],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
@@ -44,6 +44,7 @@ setup(
         "tornado",
         "bottle",
         "frameworks",
+    ,   "chalice"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,14 @@ from setuptools import setup, find_packages
 
 VERSION = "0.5.2"
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "mock", "Flask==1.1.2", "tornado", "bottle==0.12.18", "chalice"],
+    "tests": [
+        "pytest",
+        "mock",
+        "Flask==1.1.2",
+        "tornado",
+        "bottle==0.12.18",
+        "chalice",
+    ],
     "lint": ["flake8==3.8.0", "flake8-bugbear==20.1.4", "pre-commit>=1.18,<3.0"],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
@@ -44,7 +51,7 @@ setup(
         "tornado",
         "bottle",
         "frameworks",
-    ,   "chalice"
+        "chalice",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/apispec_webframeworks/chalice.py
+++ b/src/apispec_webframeworks/chalice.py
@@ -51,6 +51,8 @@ class ChalicePlugin(BasePlugin):
 
     def path_helper(self, operations, *, view, app, **kwargs):
         """Path helper that allows passing a chalice view function."""
+        if not isinstance(app, Chalice):
+            raise APISpecError(f"app must be an instance of chalice.Chalice")
         # parse through the documentation string to see what operations are defined
         operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
         # find the route for this view function

--- a/src/apispec_webframeworks/chalice.py
+++ b/src/apispec_webframeworks/chalice.py
@@ -33,26 +33,36 @@ class ChalicePlugin(BasePlugin):
 
     @staticmethod
     def _route_for_view(app, operations, view):
-        # iterate through the routes and create a list of operations + routes for this view function
-        routes = {}
-        # iterate through all route entries
+        # iterate through the routes and look for a match to the view function 
+        route = None
+        # in the app objet for each path there's a dict with key=method and value=entry
+        # for each operation that we're iterested in see if there's an entry
         for path in app.routes.keys():
+            # get the map of method -> entry
             methods = app.routes[path]
+            # loop through the methodsoperations indicated in the specification 
             for method in methods.keys():
-                entry = methods[method]
-                if entry.view_function == view:
-                    routes[method] = path
-        # get the route
-        route = list(routes.values())[0]
-        # make sure all of the methods point to the same route for sanity checking
-        if list(routes.values()).count(route) != len(routes):
-            raise APISpecError(f"Method mismatch for route {view}")
+                # see if there's a match for the operation 
+                if len(operations) == 0 or method.lower() in operations:
+                    # there's an entry so see if the view methods match
+                    entry = methods[method]
+                    if entry.view_function == view:                        
+                        # store the path if this is the first match 
+                        if route is None:
+                             route = path
+                        # if the view natches a different path something is wrong
+                        elif route != path:
+                            raise APISpecError(f"Duplicate route found for method {view}")
+        # make sure we found one
+        if route is None:
+            raise APISpecError(f"No route found for method {view}")
+        # success 
         return route
 
     def path_helper(self, operations, *, view, app, **kwargs):
         """Path helper that allows passing a chalice view function."""
         if not isinstance(app, Chalice):
-            raise APISpecError(f"app must be an instance of chalice.Chalice")
+            raise APISpecError(f"app must be an instance of Chalice")
         # parse through the documentation string to see what operations are defined
         operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
         # find the route for this view function

--- a/src/apispec_webframeworks/chalice.py
+++ b/src/apispec_webframeworks/chalice.py
@@ -27,24 +27,25 @@ from chalice import Chalice
 from apispec import BasePlugin, yaml_utils
 from apispec.exceptions import APISpecError
 
+
 class ChalicePlugin(BasePlugin):
     """APISpec plugin for Chalice"""
 
     @staticmethod
     def _route_for_view(app, operations, view):
-        # iterate through the routes and create a list of operations + routes for this view function 
-        routes = {} 
+        # iterate through the routes and create a list of operations + routes for this view function
+        routes = {}
         # iterate through all route entries
-        for path in app.routes.keys():          
+        for path in app.routes.keys():
             methods = app.routes[path]
             for method in methods.keys():
                 entry = methods[method]
                 if entry.view_function == view:
                     routes[method] = path
-        # get the route  
+        # get the route
         route = list(routes.values())[0]
         # make sure all of the methods point to the same route for sanity checking
-        if (list(routes.values()).count(route) != len(routes)):
+        if list(routes.values()).count(route) != len(routes):
             raise APISpecError(f"Method mismatch for route {view}")
         return route
 
@@ -52,7 +53,7 @@ class ChalicePlugin(BasePlugin):
         """Path helper that allows passing a chalice view function."""
         # parse through the documentation string to see what operations are defined
         operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
-        # find the route for this view function 
+        # find the route for this view function
         route = self._route_for_view(app, operations, view)
         # if we didn't throw an exception then the view function handles all operations found in the docs
         return route

--- a/src/apispec_webframeworks/chalice.py
+++ b/src/apispec_webframeworks/chalice.py
@@ -33,30 +33,32 @@ class ChalicePlugin(BasePlugin):
 
     @staticmethod
     def _route_for_view(app, operations, view):
-        # iterate through the routes and look for a match to the view function 
+        # iterate through the routes and look for a match to the view function
         route = None
         # in the app objet for each path there's a dict with key=method and value=entry
         # for each operation that we're iterested in see if there's an entry
         for path in app.routes.keys():
             # get the map of method -> entry
             methods = app.routes[path]
-            # loop through the methodsoperations indicated in the specification 
+            # loop through the methodsoperations indicated in the specification
             for method in methods.keys():
-                # see if there's a match for the operation 
+                # see if there's a match for the operation
                 if len(operations) == 0 or method.lower() in operations:
                     # there's an entry so see if the view methods match
                     entry = methods[method]
-                    if entry.view_function == view:                        
-                        # store the path if this is the first match 
+                    if entry.view_function == view:
+                        # store the path if this is the first match
                         if route is None:
-                             route = path
+                            route = path
                         # if the view natches a different path something is wrong
                         elif route != path:
-                            raise APISpecError(f"Duplicate route found for method {view}")
+                            raise APISpecError(
+                                f"Duplicate route found for method {view}"
+                            )
         # make sure we found one
         if route is None:
             raise APISpecError(f"No route found for method {view}")
-        # success 
+        # success
         return route
 
     def path_helper(self, operations, *, view, app, **kwargs):

--- a/src/apispec_webframeworks/chalice.py
+++ b/src/apispec_webframeworks/chalice.py
@@ -1,0 +1,58 @@
+"""Chalice plugin. Includes a path helper that allows you to pass a view function
+to `path`.
+::
+
+    from chalice import Chalice
+    app = Chalice(__name__)
+
+    @app.route('/gists/{gist_id}')
+    def gist_detail(gist_id):
+        '''Gist detail view.
+        ---
+        get:
+            responses:
+                200:
+                    schema:
+                        $ref: '#/definitions/Gist'
+        '''
+        return 'detail for gist {}'.format(gist_id)
+
+    spec.path(view=gist_detail, app=app)
+    print(spec.to_dict()['paths'])
+    # {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}}
+"""
+
+from chalice import Chalice
+
+from apispec import BasePlugin, yaml_utils
+from apispec.exceptions import APISpecError
+
+class ChalicePlugin(BasePlugin):
+    """APISpec plugin for Chalice"""
+
+    @staticmethod
+    def _route_for_view(app, operations, view):
+        # iterate through the routes and create a list of operations + routes for this view function 
+        routes = {} 
+        # iterate through all route entries
+        for path in app.routes.keys():          
+            methods = app.routes[path]
+            for method in methods.keys():
+                entry = methods[method]
+                if entry.view_function == view:
+                    routes[method] = path
+        # get the route  
+        route = list(routes.values())[0]
+        # make sure all of the methods point to the same route for sanity checking
+        if (list(routes.values()).count(route) != len(routes)):
+            raise APISpecError(f"Method mismatch for route {view}")
+        return route
+
+    def path_helper(self, operations, *, view, app, **kwargs):
+        """Path helper that allows passing a chalice view function."""
+        # parse through the documentation string to see what operations are defined
+        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
+        # find the route for this view function 
+        route = self._route_for_view(app, operations, view)
+        # if we didn't throw an exception then the view function handles all operations found in the docs
+        return route

--- a/tests/test_ext_chalice.py
+++ b/tests/test_ext_chalice.py
@@ -1,0 +1,106 @@
+import pytest
+
+from chalice import Chalice
+
+from apispec import APISpec
+from apispec_webframeworks.chalice import ChalicePlugin
+
+from .utils import get_paths
+
+
+@pytest.fixture(params=("2.0", "3.0.0"))
+def spec(request):
+    return APISpec(
+        title="Swagger Petstore",
+        version="1.0.0",
+        openapi_version=request.param,
+        plugins=(ChalicePlugin(),),
+    )
+
+
+@pytest.fixture()
+def app():
+    return Chalice(__name__)
+
+class TestPathHelpers:
+    def test_path_from_view(self, app, spec):
+        @app.route("/hello")
+        def hello():
+            return "hi"
+
+        spec.path(
+            view=hello, app=app, operations={"get": {"parameters": [], "responses": {"200": {}}}}
+        )
+        paths = get_paths(spec)
+        assert "/hello" in paths
+        assert "get" in paths["/hello"]
+        expected = {"parameters": [], "responses": {"200": {}}}
+        assert paths["/hello"]["get"] == expected
+
+    def test_path_with_multiple_methods(self, app, spec):
+        @app.route("/hello", methods=["GET", "POST"])
+        def hello():
+            return "hi"
+
+        spec.path(
+            view=hello,
+            operations=dict(
+                get={"description": "get a greeting", "responses": {"200": {}}},
+                post={"description": "post a greeting", "responses": {"200": {}}},
+            ),
+            app=app
+        )
+        paths = get_paths(spec)
+        get_op = paths["/hello"]["get"]
+        post_op = paths["/hello"]["post"]
+        assert get_op["description"] == "get a greeting"
+        assert post_op["description"] == "post a greeting"
+
+    def test_integration_with_docstring_introspection(self, app, spec):
+        @app.route("/hello")
+        def hello():
+            """A greeting endpoint.
+
+            ---
+            x-extension: value
+            get:
+                description: get a greeting
+                responses:
+                    200:
+                        description: a pet to be returned
+                        schema:
+                            $ref: #/definitions/Pet
+
+            post:
+                description: post a greeting
+                responses:
+                    200:
+                        description: some data
+
+            foo:
+                description: not a valid operation
+                responses:
+                    200:
+                        description:
+                            more junk
+            """
+            return "hi"
+
+        spec.path(view=hello, app=app)
+        paths = get_paths(spec)
+        get_op = paths["/hello"]["get"]
+        post_op = paths["/hello"]["post"]
+        extension = paths["/hello"]["x-extension"]
+        assert get_op["description"] == "get a greeting"
+        assert post_op["description"] == "post a greeting"
+        assert "foo" not in paths["/hello"]
+        assert extension == "value"
+
+    def test_path_is_translated_to_swagger_template(self, app, spec):
+        @app.route("/pet/{pet_id}")
+        def get_pet(pet_id):
+            return f"representation of pet {pet_id}"
+
+        spec.path(view=get_pet, app=app)
+        assert "/pet/{pet_id}" in get_paths(spec)
+

--- a/tests/test_ext_chalice.py
+++ b/tests/test_ext_chalice.py
@@ -22,6 +22,7 @@ def spec(request):
 def app():
     return Chalice(__name__)
 
+
 class TestPathHelpers:
     def test_path_from_view(self, app, spec):
         @app.route("/hello")
@@ -29,7 +30,9 @@ class TestPathHelpers:
             return "hi"
 
         spec.path(
-            view=hello, app=app, operations={"get": {"parameters": [], "responses": {"200": {}}}}
+            view=hello,
+            app=app,
+            operations={"get": {"parameters": [], "responses": {"200": {}}}},
         )
         paths = get_paths(spec)
         assert "/hello" in paths
@@ -44,11 +47,11 @@ class TestPathHelpers:
 
         spec.path(
             view=hello,
+            app=app,
             operations=dict(
                 get={"description": "get a greeting", "responses": {"200": {}}},
                 post={"description": "post a greeting", "responses": {"200": {}}},
             ),
-            app=app
         )
         paths = get_paths(spec)
         get_op = paths["/hello"]["get"]
@@ -103,4 +106,3 @@ class TestPathHelpers:
 
         spec.path(view=get_pet, app=app)
         assert "/pet/{pet_id}" in get_paths(spec)
-


### PR DESCRIPTION
I've written a path plugin for the AWS Chalice framework to make it a bit easier to create a specification using Chalice path routes. 