### PR TITLE
Emphasize the 3 dashes are key; explain usage with autodoc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ To mitigate that one can make autodoc find the YAML just like apispec's
 
 
     def setup(app):
-        app.connect('autodoc-process-docstring', handle_apispec_in_docstring)
+        app.connect("autodoc-process-docstring', handle_apispec_in_docstring)
 
 
 Or, to preserve and format the YAML:
@@ -158,12 +158,14 @@ Or, to preserve and format the YAML:
         # prepend reST instructions
         del lines[idx]
         lines[idx:] = map(lambda s: "    {}".format(s), lines[idx:])
-        lines[idx:idx] = textwrap.dedent("""
+        lines[idx:idx] = textwrap.dedent(
+            """
             This defines the following OpenAPI fragment:
 
             .. code-block:: yaml
 
-            """).splitlines()
+            """
+        ).splitlines()
 
 Development
 ===========

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ To mitigate that one can make autodoc find the YAML just like apispec's
 
 
     def setup(app):
-        app.connect("autodoc-process-docstring', handle_apispec_in_docstring)
+        app.connect("autodoc-process-docstring", handle_apispec_in_docstring)
 
 
 Or, to preserve and format the YAML:


### PR DESCRIPTION
This documentation-only fix emphasises that the 3 dashes are key for apispec, hence are required. And it explains how not to run into errors when using Sphinx' autodoc extension to generate documentation.

The Sphinx example to find the (assumed) YAML uses the same code as https://github.com/marshmallow-code/apispec/blob/4.0.0b1/src/apispec/yaml_utils.py#L26-L33