### PR TITLE
Allow optional usage of plugin

### DIFF
--- a/src/apispec_webframeworks/flask.py
+++ b/src/apispec_webframeworks/flask.py
@@ -107,8 +107,12 @@ class FlaskPlugin(BasePlugin):
         rule = app.url_map._rules_by_endpoint[endpoint][0]
         return rule
 
-    def path_helper(self, operations, *, view, app=None, **kwargs):
+    def path_helper(self, operations, *, view=None, app=None, **kwargs):
         """Path helper that allows passing a Flask view function."""
+        
+        if not view:
+            return
+        
         rule = self._rule_for_view(view, app=app)
         operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
         if hasattr(view, "view_class") and issubclass(view.view_class, MethodView):


### PR DESCRIPTION
Hello there,

I was wondering if you would consider allowing optional usage of the Flask Plugin in the event that the end user needs to manually add endpoints outside of Flask docstrings? 

Currently, if you do not provide a view kwarg when constructing a path, an error is thrown.

It's a very small, non-breaking change, so I hope that you'll consider it. 

Thanks for all your work on the module.

Cheers,