### PR TITLE
Modernize package by replacing pkg_resources with importlib.metadata

### DIFF
--- a/src/apispec_webframeworks/__init__.py
+++ b/src/apispec_webframeworks/__init__.py
@@ -1,5 +1,3 @@
-import pkg_resources
+from importlib.metadata import distribution
 
-__version__ = str(
-    pkg_resources.get_distribution("apispec-webframeworks").parsed_version
-)
+__version__ = str(distribution("apispec-webframeworks").version)


### PR DESCRIPTION
Hello, 

I've been inspired by [this issue](https://github.com/marshmallow-code/apispec-webframeworks/issues/108) to modernize the package by replacing the deprecated pkg_resources by importlib.metadata.
