### PR TITLE
Consistent ordering for HTTP path keys

### DIFF
--- a/src/apispec_webframeworks/tornado.py
+++ b/src/apispec_webframeworks/tornado.py
@@ -52,7 +52,7 @@ class TornadoPlugin(BasePlugin):
         :param handler_class:
         :type handler_class: RequestHandler descendant
         """
-        for httpmethod in yaml_utils.PATH_KEYS:
+        for httpmethod in sorted(yaml_utils.PATH_KEYS):
             method = getattr(handler_class, httpmethod)
             docstring = method.__doc__ or ""
             operation_data = yaml_utils.load_yaml_from_docstring(docstring)


### PR DESCRIPTION
yaml_utils.PATH_KEYS is a set of strings, which does not have consistent ordering across python sessions due to the fact that python's string hash uses a random seed. This results in  openAPI documents changing their order every time you generate them for a set of routes.

Applying sorted to the path keys before iterating ensures the openAPI spec will be deterministically ordered every time it is generated.