### PR TITLE
support distinct routes for methods

### DIFF
--- a/src/apispec_webframeworks/flask.py
+++ b/src/apispec_webframeworks/flask.py
@@ -150,7 +150,7 @@ class FlaskPlugin(BasePlugin):
             view = self._view_for_rule(rule, app=app)
         view_doc = view.__doc__ or ""
         doc_operations = yaml_utils.load_operations_from_docstring(view_doc)
-        doc_operations = {k: v for k, v in doc_operations.items() if k.upper() in rule.methods}
+        doc_operations = {k: v for k, v in doc_operations.items() if k.upper() in rule.methods or k.startswith("x-")}
         operations.update(doc_operations)
         if hasattr(view, "view_class") and issubclass(view.view_class, MethodView):  # noqa: E501
             # method attribute is dynamically added, which is supported by mypy

--- a/src/apispec_webframeworks/flask.py
+++ b/src/apispec_webframeworks/flask.py
@@ -150,6 +150,7 @@ class FlaskPlugin(BasePlugin):
             view = self._view_for_rule(rule, app=app)
         view_doc = view.__doc__ or ""
         doc_operations = yaml_utils.load_operations_from_docstring(view_doc)
+        doc_operations = {k: v for k, v in doc_operations.items() if k.upper() in rule.methods}
         operations.update(doc_operations)
         if hasattr(view, "view_class") and issubclass(view.view_class, MethodView):  # noqa: E501
             # method attribute is dynamically added, which is supported by mypy

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -124,7 +124,7 @@ class TestPathHelpers:
         assert "delete" not in paths["/hi"]
 
     def test_integration_with_docstring_introspection(self, app, spec):
-        @app.route("/hello")
+        @app.route("/hello", methods=["GET", "POST"])
         def hello():
             """A greeting endpoint.
 

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -180,3 +180,32 @@ class TestPathHelpers:
 
         spec.path(view=get_pet, app=app)
         assert "/pet/{pet_id}" in get_paths(spec)
+
+    def test_multiple_paths(self, app, spec):
+        @app.put("/user")
+        @app.route("/user/<user>")
+        def user(user = None):
+            """A greeting endpoint.
+
+            ---
+            get:
+                description: get user details
+                responses:
+                    200:
+                        description: a user to be returned
+            put:
+                description: create a user
+                responses:
+                    200:
+                        description: some data
+            """
+            pass
+
+        for rule in app.url_map.iter_rules():
+            spec.path(rule=rule)
+
+        paths = get_paths(spec)
+        get_op = paths["/user/{user}"]["get"]
+        put_op = paths["/user"]["put"]
+        assert get_op["description"] == "get user details"
+        assert put_op["description"] == "create a user"


### PR DESCRIPTION
I would like to add support for endpoints like this

```python
@app.put("/user")
@app.route("/user/<user>")
def user(user = None):
    """A greeting endpoint.

    ---
    get:
        description: get user details
        responses:
            200:
                description: a user to be returned
    put:
        description: create a user
        responses:
            200:
                description: some data
    """
    pass
```

that define different paths on top of the same handler. Currently this would result in wrong spec like this:
```json
{
  "paths": {
    "/user/{user}": {
      "get": {
        "description": "get user details",
        "responses": {
          "200": {
            "description": "a user to be returned"
          }
        }
      },
      "put": {
        "description": "create a user",
        "responses": {
          "200": {
            "description": "some data"
          }
        }
      }
    }
  }
}
```
note that all methods get attributed to whatever path comes in last.

with this change we can render the correct data
```json
{
  "paths": {
    "/user/{user}": {
      "get": {
        "description": "get user details",
        "responses": {
          "200": {
            "description": "a user to be returned"
          }
        }
      }
    },
    "/user": {
      "put": {
        "description": "create a user",
        "responses": {
          "200": {
            "description": "some data"
          }
        }
      }
    }
  }
}
```

note that for this to work, users must adapt the way they call into the library a bit.

```diff
- spec.path(view=view)
+ spec.path(rule=rule)
```

as based on the handler function alone we cannot deduce what path, and hence which methods, matched.

without this change users can circumvent this issue by splitting their handler functions up, s.t. we have a 1:1 mapping between endpoints and handlers.

please excuse the a bit nonsensical example.